### PR TITLE
Fix missing dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     ["uota.py", "github:mkomon/uota/lib/uota.py"]
   ],
   "deps": [
-    ["utarfile"]
+    ["utarfile", "latest"]
   ],
   "version": "0.1"
 }


### PR DESCRIPTION
Missing dependency version resulting error
```
MicroPython v1.20.0 on 2023-04-26; ESP module with ESP8266
Type "help()" for more information.
>>> import mip
>>> mip.install('github:mkomon/uota')
Installing github:mkomon/uota/package.json to /lib
Copying: /lib/uota.py
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mip/__init__.py", line 1, in install
  File "mip/__init__.py", line 1, in _install_package
  File "mip/__init__.py", line 1, in _install_json
ValueError: need more than 1 values to unpack
```
After fix:
```
>>> mip.install('github:bilabar/uota', version='temp-fix')
Installing github:bilabar/uota/package.json to /lib
Copying: /lib/uota.py
Installing utarfile (latest) from https://micropython.org/pi/v2 to /lib
Copying: /lib/utarfile.mpy
Done
```