### PR TITLE
Update to mp v1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Update your device firmware written in MicroPython over the air. Suitable for pr
 
 Compatibility:
 
-- v0.1 requires MicroPython 1.17 or newer
+- v0.1 requires MicroPython 1.17 - 1.20
 - v0.2 requires MicroPython 1.21 or newer
 
 ## How it's different from other OTA Updaters

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 Update your device firmware written in MicroPython over the air. Suitable for private and/or larger projects with many files.
 
-Requires MicroPython 1.17 or newer.
+Compatibility:
+
+- v0.1 requires MicroPython 1.17 or newer
+- v0.2 requires MicroPython 1.21 or newer
 
 ## How it's different from other OTA Updaters
 

--- a/lib/uota.py
+++ b/lib/uota.py
@@ -7,8 +7,8 @@ MIT license; Copyright (c) 2021 Martin Komon
 import gc
 import uos
 import urequests
-import uzlib
-import utarfile as tarfile
+import deflate
+import tarfile
 from micropython import const
 
 try:
@@ -35,8 +35,6 @@ except ImportError:
     log.warning('ucertpin package not found, certificate pinning is disabled')
     ucertpin_available = False
 
-
-GZDICT_SZ = const(31)
 ota_config = {}
 
 def load_ota_cfg():
@@ -169,7 +167,7 @@ def install_new_firmware(quiet=False):
         return
 
     with open(ota_config['tmp_filename'], 'rb') as f1:
-        f2 = uzlib.DecompIO(f1, GZDICT_SZ)
+        f2 = deflate.DeflateIO(f1, deflate.GZIP)
         f3 = tarfile.TarFile(fileobj=f2)
         for _file in f3:
             file_name = _file.name
@@ -203,4 +201,3 @@ def install_new_firmware(quiet=False):
     if load_ota_cfg():
         for filename in ota_config['delete']:
             recursive_delete(filename)
-

--- a/lib/uota.py
+++ b/lib/uota.py
@@ -180,7 +180,7 @@ def install_new_firmware(quiet=False):
 
             if file_name.endswith('/'):  # is a directory
                 try:
-                    not quiet and log.debug(f'creating directory {file_name} ... ', end='')
+                    not quiet and log.debug(f'creating directory {file_name} ... ')
                     uos.mkdir(file_name[:-1])  # without trailing slash or fail with errno 2
                     not quiet and log.debug('ok')
                 except OSError as e:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     ["uota.py", "github:mkomon/uota/lib/uota.py"]
   ],
   "deps": [
-    ["utarfile", "latest"]
+    ["tarfile", "latest"]
   ],
-  "version": "0.1"
+  "version": "0.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "urls": [
-    ["uota.py", "github:mkomon/uota/lib/uota.py"]
+    ["uota.py", "github:ThinkTransit/uota/lib/uota.py"]
   ],
   "deps": [
     ["tarfile", "latest"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "urls": [
-    ["uota.py", "github:ThinkTransit/uota/lib/uota.py"]
+    ["uota.py", "github:mkomon/uota/lib/uota.py"]
   ],
   "deps": [
     ["tarfile", "latest"]


### PR DESCRIPTION
uota doesn't work with recent versions of mp (after v1.21) because the deflate module has been added.

This pr replaces uzlib with deflate