### PR TITLE
fix minor bugs + minor refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.2.1
+
+- fix TypeError introduced in 0.2 (PR#10, credit WFLM)
+- fix checking new version (PR#10, credit WFLM)
+- start changelog
+
+## 0.2
+
+- add basic HTTP authentication (PR#9, credit ThinkTransit)
+- update to support MicroPython 1.21 or later (PR#8, credit ThinkTransit)

--- a/lib/uota.py
+++ b/lib/uota.py
@@ -44,7 +44,7 @@ def load_ota_cfg():
             ota_config.update(eval(f.read()))
         return True
     except OSError:
-        log.error("Cannot find uota config file 'uota.cfg'. OTA is disabled")
+        log.error('Cannot find uota config file `uota.cfg`. OTA is disabled.')
         return False
 
 
@@ -161,7 +161,7 @@ def check_for_updates(version_check=True, quiet=False, pubkey_hash=b'') -> bool:
                     hash_obj.update(chunk)
                 f.write(chunk)
         if remote_hash and ubinascii.hexlify(hash_obj.digest()).decode() != remote_hash:
-            not quiet and log.error("hashes don't match, cannot install the new firmware")
+            not quiet and log.error('hashes don\'t match, cannot install the new firmware')
             uos.remove(ota_config['tmp_filename'])
             return False
         return True

--- a/lib/uota.py
+++ b/lib/uota.py
@@ -91,7 +91,7 @@ def check_free_space(min_free_space: int) -> bool:
 
 
 def normalize_version(version: str) -> tuple[str, ...]:
-    return tuple(point.zfill(8) for point in version.split('.'))
+    return tuple(f'{point:0>8}' for point in version.split('.'))
 
 
 def check_for_updates(version_check=True, quiet=False, pubkey_hash=b'') -> bool:

--- a/package.json
+++ b/package.json
@@ -5,5 +5,5 @@
   "deps": [
     ["tarfile", "latest"]
   ],
-  "version": "0.2"
+  "version": "0.2.1"
 }

--- a/test/test_uota.py
+++ b/test/test_uota.py
@@ -1,7 +1,22 @@
+"""
+testing suite for uota
+
+written using raw MicroPython code, not depending on any testing framework
+suited to be copy/pasted into MicroPython REPL on a microcontroller to run all tests
+
+"""
+
 from uota import *
+
+# test definitions
 
 def test_normalize_version():
     nv = normalize_version
     assert nv("0.0.10") > nv("0.0.9")
     assert nv("0.2.1") > nv("0.2")
     assert nv("0.3") > nv("0.2.1")
+    print("normalize_version ok")
+
+
+# test execution
+test_normalize_version()

--- a/test/test_uota.py
+++ b/test/test_uota.py
@@ -1,0 +1,7 @@
+from uota import *
+
+def test_normalize_version():
+    nv = normalize_version
+    assert nv("0.0.10") > nv("0.0.9")
+    assert nv("0.2.1") > nv("0.2")
+    assert nv("0.3") > nv("0.2.1")

--- a/test/test_uota.py
+++ b/test/test_uota.py
@@ -1,9 +1,10 @@
 """
-testing suite for uota
+Testing suite for uota.
 
-written using raw MicroPython code, not depending on any testing framework
-suited to be copy/pasted into MicroPython REPL on a microcontroller to run all tests
+Written using raw MicroPython code, not depending on any testing framework.
+Suited to be copy/pasted into MicroPython REPL on a microcontroller to run all tests.
 
+MIT license; Copyright (c) 2024 Martin Komon
 """
 
 from uota import *
@@ -15,6 +16,7 @@ def test_normalize_version():
     assert nv("0.0.10") > nv("0.0.9")
     assert nv("0.2.1") > nv("0.2")
     assert nv("0.3") > nv("0.2.1")
+    assert nv("0.3.0") > nv("0.3")  # more specific > general == true, I guess
     print("normalize_version ok")
 
 


### PR DESCRIPTION
1. 114 line caused TypeError
2. Version comparison did not work correctly if the minor value was greater than one character.  
For example: ('0.0.9' > '0.0.10') was True